### PR TITLE
Send small files using PutObject

### DIFF
--- a/lib/ex_webrtc_recorder/s3/utils.ex
+++ b/lib/ex_webrtc_recorder/s3/utils.ex
@@ -2,15 +2,21 @@ if Code.ensure_loaded?(ExAws.S3) do
   defmodule ExWebRTC.Recorder.S3.Utils do
     @moduledoc false
 
+    @chunk_size 5 * 1024 * 1024
+
     @spec upload_file(Path.t(), String.t(), String.t(), keyword()) :: {:ok | :error, term()}
     def upload_file(path, s3_bucket_name, s3_path, s3_config \\ []) do
-      path
-      |> ExAws.S3.Upload.stream_file()
-      |> ExAws.S3.upload(s3_bucket_name, s3_path)
+      case File.stat!(path) do
+        %File.Stat{size: size} when size != :undefined and size <= @chunk_size ->
+          ExAws.S3.put_object(s3_bucket_name, s3_path, File.read!(path))
+
+        _else ->
+          path
+          |> ExAws.S3.Upload.stream_file()
+          |> ExAws.S3.upload(s3_bucket_name, s3_path)
+      end
       |> ExAws.request(s3_config)
     end
-
-    @chunk_size 5 * 1024 * 1024
 
     @spec upload_manifest(ExWebRTC.Recorder.Manifest.t(), String.t(), String.t(), keyword()) ::
             {:ok | :error, term()}


### PR DESCRIPTION
Use the PutObject API intead of multipart requests.

It seems that their is inconsistency in various provider APIs when sending empty files using the multipart API and there are [hacks in ex_aws](https://github.com/ex-aws/ex_aws_s3/blob/9ec181b45787f684d59d4830cedcf7377f16aaeb/lib/ex_aws/s3/upload.ex#L41).

This mitigates the issue and prevents unnecessarily complicated object uploads for small files.

Closes FCE-2005